### PR TITLE
feat(evaluations): add support for HuggingFace token in model loading

### DIFF
--- a/src/mhai/evaluations/base.py
+++ b/src/mhai/evaluations/base.py
@@ -20,11 +20,13 @@ class ModelBase(ABC):
     def __init__(
         self,
         model_name: Optional[str] = None,
+        token: Optional[str] = None,
         temperature: Optional[float] = None,
         output_max_length: Optional[int] = None,
         api_params: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.model_name = model_name or self.default_model_name
+        self.token = token
         self.temperature = (
             temperature
             if temperature is not None

--- a/src/mhai/evaluations/mental.py
+++ b/src/mhai/evaluations/mental.py
@@ -20,7 +20,8 @@ def get_mental_pipeline(model_name: str, **kwargs: Any) -> Any:
     return pipeline(
         task='text-classification',
         model=model_name,
-        **params,
+        top_k=None,  # returns all labels
+        **kwargs,
     )
 
 


### PR DESCRIPTION
### **Description:**
Adds optional token support to ModelBase and mental.py to enable loading gated Hugging Face models (e.g., mental/mental-bert-base-uncased).